### PR TITLE
remove console.log from output

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -88,12 +88,7 @@ export const gen = (name: string, options?: GenOptions): Action<any, any> => {
     const isOutputToArray = context.leafId
       .slice(-2)
       .every((x) => typeof x === "number") && context.leafId.length > 1;
-    console.log({
-      isMulti,
-      n: options?.n,
-      outputToArray: isOutputToArray,
-      address: context.leafId,
-    });
+
     if (!isOutputToArray)
       outputs[name] = isMulti ? fullStrings : fullStrings[0];
     else {


### PR DESCRIPTION
Hey nice project! I am really finding it quite useful. 
I noticed this console.log appearing in terminal output and figured it might have been left there by mistake. If you actually want it in there happy to adjust to your liking regarding flags or whatever but as a user I would rather control my terminal output if possible. 